### PR TITLE
live555: change the docker registry to us-central1

### DIFF
--- a/live555/conf/default.env
+++ b/live555/conf/default.env
@@ -1,2 +1,2 @@
-LIVE555_DOCKER_IMAGE=gcr.io/test-bai/live555
+LIVE555_DOCKER_IMAGE=us-central1-docker.pkg.dev/ext-edge-analytics/docker/live555
 LIVE555_DOCKER_TAG=latest


### PR DESCRIPTION
Previous registry is wrong: us-central1-docker.pkg.dev/ext-edge-analytics/docker/ is the right one