### PR TITLE
MCPEvents: support variable framerates

### DIFF
--- a/docs/examples/MCPEvents/MCPEventAnnotator.py
+++ b/docs/examples/MCPEvents/MCPEventAnnotator.py
@@ -25,6 +25,7 @@ class MCPEventAnnotator:
             self.roi_filter = ROIFilter(sensors_json)
 
     def annotate_frame_with_event(self, frame, data):
+        annotated = False
         metaclasses = data['metaClasses']
         frame_dimensions = data['frameDimensions']
         region_map = None
@@ -51,6 +52,8 @@ class MCPEventAnnotator:
                     cv2.rectangle(frame, (int(x+w), int(y+h)), (int(x),int(y)), color, 2)
                     cv2.putText(frame, obj_dict['class'], (int(x),int(y+8)), cv2.FONT_HERSHEY_SIMPLEX,
                                     1, color, 2, cv2.LINE_AA)
+                    annotated = True
+        return annotated
 
     def annotate_frame_with_sensors(self, frame):
         poly_points = {}
@@ -65,43 +68,75 @@ class MCPEventAnnotator:
             for name in poly_points.keys():
                 cv2.polylines(frame, [poly_points[name]], True, (255,0,0), 2)
 
-    def create_annotation(self, jsonfile, vidfile, annotated_vid):
-        event_segment = json.load(open(jsonfile))
+    def get_overall_fps(self, vidfile):
         vid_capture = cv2.VideoCapture(str(vidfile))
         fps = vid_capture.get(cv2.CAP_PROP_FPS)
-        frame_advance_ts = 1000/fps
-        total_frames = (event_segment['end_ts'] - event_segment['start_ts']) / frame_advance_ts
+        if fps > 60 or fps < 0:
+            print(f"Found bogus fps {fps}, calculating")
+            reported_fps = fps
+            last_frame = 0
+            last_time = 0
+            # See https://stackoverflow.com/a/52463543
+            while vid_capture.isOpened():
+                ret, frame = vid_capture.read()
+                if ret:
+                    time = vid_capture.get(cv2.CAP_PROP_POS_MSEC)
+                    if time > last_time:
+                        last_time = time
+                    elif last_frame > 0:
+                        print(f"Got bogus time {time} on frame {last_frame}")
+                    last_frame = last_frame +1
+                else:
+                    break
+            if last_frame == 0:
+                fps = 0
+            else:
+                fps = last_frame / (last_time/1000)
+            print(f"Found bogus FPS {reported_fps} in video, calculated overall fps {fps}")
+
+        return fps
+
+    def create_annotation(self, jsonfile, vidfile, annotated_vid):
+        event_segment = json.load(open(jsonfile))
         frame_count = 0
-        frame_ts = event_segment['start_ts']
         event_list_index = 0
+        annotated_frame_count = 0
+        overall_fps = self.get_overall_fps(vidfile)
+        vid_capture = cv2.VideoCapture(str(vidfile))
         frame_size = (int(vid_capture.get(cv2.CAP_PROP_FRAME_WIDTH)),
                         int(vid_capture.get(cv2.CAP_PROP_FRAME_HEIGHT)))
         output = cv2.VideoWriter(str(annotated_vid),
-                                cv2.VideoWriter_fourcc('M','P','4','V'),
-                                vid_capture.get(cv2.CAP_PROP_FPS),
+                                cv2.VideoWriter_fourcc('m','p','4','v'),
+                                overall_fps,
                                 frame_size)
-
+        ret, frame = vid_capture.read()
         while(vid_capture.isOpened()):
         # vid_capture.read() methods returns a tuple, first element is a bool
         # and the second is frame
-            ret, frame = vid_capture.read()
+            video_ts_ms = vid_capture.get(cv2.CAP_PROP_POS_MSEC)
+            next_ret, next_frame = vid_capture.read()
+            video_ts_next = vid_capture.get(cv2.CAP_PROP_POS_MSEC)
             frame_count = frame_count + 1
+            frame_ts = event_segment['start_ts'] + video_ts_ms
+            frame_ts_next = event_segment['start_ts'] + video_ts_next
             if ret == True:
-                frame_ts_next = frame_ts + frame_advance_ts
                 if event_list_index < len(event_segment['events_list']):
                     next_event = event_segment['events_list'][event_list_index]
                     if frame_ts <= next_event['frameTimestamp'] <= frame_ts_next:
-                        self.annotate_frame_with_event(frame, next_event)
+                        if self.annotate_frame_with_event(frame, next_event):
+                            annotated_frame_count = annotated_frame_count +1
                         event_list_index = event_list_index + 1
                 self.annotate_frame_with_sensors(frame)
                 # Write the frame to the output files
                 output.write(frame)
                 print(f"Wrote frame {frame_count}")
-                frame_ts = frame_ts_next
+                frame = next_frame
+                ret = next_ret
             else:
                 print("Stream ended")
                 break
 
+        print(f"Processed {len(event_segment['events_list'])} events, annotated {annotated_frame_count} frames")
         vid_capture.release()
         output.release()
 

--- a/docs/examples/MCPEvents/MCPEventAnnotator.py
+++ b/docs/examples/MCPEvents/MCPEventAnnotator.py
@@ -119,17 +119,27 @@ class MCPEventAnnotator:
             frame_count = frame_count + 1
             frame_ts = event_segment['start_ts'] + video_ts_ms
             frame_ts_next = event_segment['start_ts'] + video_ts_next
+            annotated_frame = False
             if ret == True:
                 if event_list_index < len(event_segment['events_list']):
                     next_event = event_segment['events_list'][event_list_index]
-                    if frame_ts <= next_event['frameTimestamp'] <= frame_ts_next:
+                    while frame_ts <= next_event['frameTimestamp'] <= frame_ts_next:
                         if self.annotate_frame_with_event(frame, next_event):
+                            print(f"Wrote frame {frame_count} and annotated with event at timestamp {next_event['frameTimestamp']}")
                             annotated_frame_count = annotated_frame_count +1
+                            annotated_frame = True
                         event_list_index = event_list_index + 1
+                        if event_list_index < len(event_segment['events_list']):
+                            next_event = event_segment['events_list'][event_list_index]
+                        else:
+                            break
+
+
                 self.annotate_frame_with_sensors(frame)
                 # Write the frame to the output files
                 output.write(frame)
-                print(f"Wrote frame {frame_count}")
+                if not annotated_frame:
+                    print(f"Wrote frame {frame_count} without event annotation")
                 frame = next_frame
                 ret = next_ret
             else:


### PR DESCRIPTION
This PR implements a simple variable framerate support implementation, necessary when we have dropped frames in video.

* If the FPS isn't reported (because it's variable), calculate the average FPS by reading all frames of the video and calculating number of frames/total time.
* When reading each frame, compute the delta between previous and next frame, and draw annotations for any events which occur in this range on the earlier of the two frames.
* Add some logging to help determine when this situation is happening and how many frames/events were ultimately annotated.